### PR TITLE
fix: invalid_argument when sending the user id

### DIFF
--- a/src/StackdriverLogging.php
+++ b/src/StackdriverLogging.php
@@ -74,7 +74,7 @@ class StackdriverLogging extends AbstractProcessingHandler
         $this->labels += [
             'route' => $_SERVER['HTTP_HOST'] ? $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : 'Not Found',
             'typeLogs' => 'default',
-            'userId' => !empty(auth()->id()) ? auth()->id() : '0'
+            'userId' => !empty(auth()->id()) ? auth()->id() . "" : '0'
         ]; 
         // set options, according to Google Stackdirver API documentation
         $options = [


### PR DESCRIPTION
The user id should be sended like a string not a number or you will get an error like this:

```
{ "error": { "code": 400, "message": "Invalid value at 'entries[0].labels[4].value' (TYPE_STRING), 20", "status": "INVALID_ARGUMENT", "details": [ { "@type": "type.googleapis.com/google.rpc.BadRequest", "fieldViolations": [ { "field": "entries[0].labels[4].value", "description": "Invalid value at 'entries[0].labels[4].value' (TYPE_STRING), 20" } ] } ] } }
```
