### PR TITLE
Logs have no trace info

### DIFF
--- a/src/StackdriverLogging.php
+++ b/src/StackdriverLogging.php
@@ -86,9 +86,16 @@ class StackdriverLogging extends AbstractProcessingHandler
         $data = [
             'message' => $record['message'],
         ];
-        if ($record['context']) {
-            $data['context'] = $record['context'];
+
+        // Add exception data to payload
+        if (is_array($record['context']) && isset($record['context']['exception'])) {
+            $data['code'] = $record['context']['exception']->getCode();
+            $data['severity'] = $record['context']['exception']->getSeverity();
+            $data['file'] = $record['context']['exception']->getFile();
+            $data['line'] = $record['context']['exception']->getLine();
+            $data['trace'] = $record['context']['exception']->getTraceAsString();
         }
+
         // write the entry
         $entry = $this->logger->entry($data, $options);
         $this->logger->write($entry);

--- a/src/StackdriverLogging.php
+++ b/src/StackdriverLogging.php
@@ -2,6 +2,7 @@
 
 namespace LaravelStackdriverGcl;
 
+use ErrorException;
 use Google\Cloud\Logging\LoggingClient;
 use Illuminate\Support\Facades\Config;
 use Monolog\Handler\AbstractProcessingHandler;
@@ -90,10 +91,14 @@ class StackdriverLogging extends AbstractProcessingHandler
         // Add exception data to payload
         if (is_array($record['context']) && isset($record['context']['exception'])) {
             $data['code'] = $record['context']['exception']->getCode();
-            $data['severity'] = $record['context']['exception']->getSeverity();
             $data['file'] = $record['context']['exception']->getFile();
             $data['line'] = $record['context']['exception']->getLine();
-            $data['trace'] = $record['context']['exception']->getTraceAsString();
+
+            // Some exception don't have trace or severity
+            if ($record['context']['exception'] instanceof ErrorException) {
+                $data['severity'] = $record['context']['exception']->getSeverity();
+                $data['trace'] = $record['context']['exception']->getTraceAsString();    
+            }
         }
 
         // write the entry

--- a/src/StackdriverLogging.php
+++ b/src/StackdriverLogging.php
@@ -125,7 +125,7 @@ class StackdriverLogging extends AbstractProcessingHandler
                 'route' => $_SERVER['HTTP_HOST'] ? $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : 'Not Found',
                 'typeLogs' => 'customs',
                 'code' => "$code",
-                'userId' => !empty(auth()->id()) ? auth()->id() : '0'
+                'userId' => !empty(auth()->id()) ? auth()->id() . "" : '0'
             ]; 
             // Creates the log entry ### ' - Trace: '. $log->getTraceAsString()
             $entry = $this->logger->entry($log->getMessage() . ' - Line: '. $log->getLine(). ' - File: '. $log->getFile() , [


### PR DESCRIPTION
We noticed we had only the message and cannot trace the error. 
This should fix this issue.

![image](https://user-images.githubusercontent.com/36208432/124093057-c78f4f80-da57-11eb-9eb3-5476fbc89554.png)

There was also a missing auth id to convert to string on the custom log function.
